### PR TITLE
Switch to NES 2.0 for ROM outputs

### DIFF
--- a/build.py
+++ b/build.py
@@ -213,8 +213,8 @@ if __name__ == "__main__":
     if args.japanese:
         linker = "linker-j.cfg"
 
-    subprocess.run(f"ca65 {DEFINES} -o example.o -g src/{dir}/main.asm -t nes".strip(), shell = True, executable="/bin/bash")
-    subprocess.run(f"ld65 -Ln linked.txt -C {linker} -o mother_rebuilt.nes example.o", shell = True, executable="/bin/bash")
+    subprocess.run(f"ca65 {DEFINES} -o example.o -g src/{dir}/main.asm -t nes".strip(), shell = True)
+    subprocess.run(f"ld65 -Ln linked.txt -C {linker} -o mother_rebuilt.nes example.o", shell = True)
 
     resultTime = (time.time() - start_time)
     print(f"Assembly took {resultTime} seconds!")

--- a/jp.yaml
+++ b/jp.yaml
@@ -1,5 +1,5 @@
 name: MOTHER
-md5: [218503a880999363ac83945096040492]
+md5: [218503a880999363ac83945096040492, bf1e0bc9c390fdbb2b3ca22d784db7d2]
 mapper: MMC3
 header: yes
 splits:

--- a/src/global/header.asm
+++ b/src/global/header.asm
@@ -10,74 +10,160 @@
 ;----------------------------------------------------------------------------------------------------
 
 ;Byte 4.
-.byte 16                       ;PRG ROM size: 16 banks * 16KB = 256KB.
+.byte 16                       ;PRG ROM size LSB: 16 banks * 16KB = 256KB.
 
 ;----------------------------------------------------------------------------------------------------
 
 ;Byte 5.
 .ifdef VER_JP
-.byte 16                       ;CHR ROM size: 16 banks * 8KB = 128KB.
+.byte 16                       ;CHR ROM size LSB: 16 banks * 8KB = 128KB.
 .else
-.byte 32                       ;CHR ROM size: 32 banks * 8KB = 256KB.
+.byte 32                       ;CHR ROM size LSB: 32 banks * 8KB = 256KB.
 .endif
 
 ;----------------------------------------------------------------------------------------------------
 
-;76543210
-;||||||||
-;|||||||+- Mirroring: 0: horizontal (vertical arrangement) (CIRAM A10 = PPU A11)
-;|||||||              1: vertical (horizontal arrangement) (CIRAM A10 = PPU A10)
-;||||||+-- 1: Cartridge contains battery-backed PRG RAM ($6000-7FFF) or other persistent memory
-;|||||+--- 1: 512-byte trainer at $7000-$71FF (stored before PRG data)
-;||||+---- 1: Ignore mirroring control or above mirroring bit; instead provide four-screen VRAM
-;++++----- Lower nybble of mapper number
+;7654 3210
+;---------
+;NNNN FTBM
+;|||| |||+-- Hard-wired nametable layout
+;|||| |||     0: Vertical arrangement ("mirrored horizontally") or mapper-controlled
+;|||| |||     1: Horizontal arrangement ("mirrored vertically")
+;|||| ||+--- "Battery" and other non-volatile memory
+;|||| ||      0: Not present
+;|||| ||      1: Present
+;|||| |+--- 512-byte Trainer
+;|||| |      0: Not present
+;|||| |      1: Present between Header and PRG-ROM data
+;|||| +---- Alternative nametables (for mapper 4/MMC3, whether RAM is present at PPU $2000-$2FFF)
+;||||        0: No
+;||||        1: Yes
+;++++------ Mapper Number D3..D0
 ;
 ;Byte 6.
-.byte $42                       ; persistent memory
+.byte $42                       ; persistent memory, mapper 4 (MMC3)
 
 ;----------------------------------------------------------------------------------------------------
 
-;76543210
-;||||||||
-;|||||||+- VS Unisystem
-;||||||+-- PlayChoice-10 (8 KB of Hint Screen data stored after CHR data)
-;||||++--- If equal to 2, flags 8-15 are in NES 2.0 format
-;++++----- Upper nybble of mapper number
+;7654 3210
+;---------
+;NNNN 10TT
+;|||| ||++- Console type
+;|||| ||     0: Nintendo Entertainment System/Family Computer
+;|||| ||     1: Nintendo Vs. System
+;|||| ||     2: Nintendo Playchoice 10
+;|||| ||     3: Extended Console Type
+;|||| ++--- NES 2.0 identifier
+;++++------ Mapper Number D7..D4
 ;
 ;Byte 7.
-.byte $00
+.byte $08 ; Mapper 04 (MMC3), NES 2.0
 
 ;----------------------------------------------------------------------------------------------------
 
-;76543210
-;||||||||
-;++++++++- PRG RAM size
+;Mapper MSB/Submapper
+;7654 3210
+;---------
+;SSSS NNNN
+;|||| ++++- Mapper number D11..D8
+;++++------ Submapper number;
 ;
 ;Byte 8.
-.byte $00                       ;No PRG RAM.
+.byte $00                       ; Mapper 4, submapper 0
 
 ;----------------------------------------------------------------------------------------------------
 
-;76543210
-;||||||||
-;|||||||+- TV system (0: NTSC; 1: PAL)
-;+++++++-- Reserved, set to zero
+;PRG-ROM/CHR-ROM size MSB
+;7654 3210
+;---------
+;CCCC PPPP
+;|||| ++++- PRG-ROM size MSB
+;++++------ CHR-ROM size MSB
 ;
 ;Byte 9.
-.byte $00                       ;NTSC.
+.byte $00                       ; PRG-ROM and CHR-ROM sizes fit in earlier bytes
 
 ;----------------------------------------------------------------------------------------------------
 
-;76543210
-;  ||  ||
-;  ||  ++- TV system (0: NTSC; 2: PAL; 1/3: dual compatible)
-;  |+----- PRG RAM ($6000-$7FFF) (0: present; 1: not present)
-;  +------ 0: Board has no bus conflicts; 1: Board has bus conflicts
+;PRG-RAM/EEPROM size
+;7654 3210
+;---------
+;pppp PPPP
+;|||| ++++- PRG-RAM (volatile) shift count
+;++++------ PRG-NVRAM/EEPROM (non-volatile) shift count
+;If the shift count is zero, there is no PRG-(NV)RAM.
+;If the shift count is non-zero, the actual size is
+;"64 << shift count" bytes, i.e. 8192 bytes for a shift count of 7.
 ;
 ;Byte 10.
-.byte $00                       ;NTSC, no PRG RAM, no bus conflicts.
+.byte $70                       ; 8192 bytes of PRG-accessible save memory
 
 ;----------------------------------------------------------------------------------------------------
 
-;Bytes 11-15.
-.byte $00, $00, $00, $00, $00   ;Unused.
+;CHR-RAM size
+;7654 3210
+;---------
+;cccc CCCC
+;|||| ++++- CHR-RAM size (volatile) shift count
+;++++------ CHR-NVRAM size (non-volatile) shift count
+;If the shift count is zero, there is no CHR-(NV)RAM.
+;If the shift count is non-zero, the actual size is
+;"64 << shift count" bytes, i.e. 8192 bytes for a shift count of 7.
+;
+;Byte 11.
+.byte $00                       ; No CHR-RAM
+
+;----------------------------------------------------------------------------------------------------
+
+;CPU/PPU Timing
+;7654 3210
+;---------
+;.... ..VV
+;       ++- CPU/PPU timing mode
+;            0: RP2C02 ("NTSC NES")
+;            1: RP2C07 ("Licensed PAL NES")
+;            2: Multiple-region
+;            3: UA6538 ("Dendy")
+;
+;Byte 12.
+.byte $00                       ; NTSC NES
+
+;----------------------------------------------------------------------------------------------------
+
+;When Byte 7 AND 3 =1: Vs. System Type
+;7654 3210
+;---------
+;MMMM PPPP
+;|||| ++++- Vs. PPU Type
+;++++------ Vs. Hardware Type
+;
+;When Byte 7 AND 3 =3: Extended Console Type
+;7654 3210
+;---------
+;.... CCCC
+;     ++++- Extended Console Type
+;
+;Byte 13.
+.byte $00                       ; None of these apply for a normal NES game
+
+;----------------------------------------------------------------------------------------------------
+
+;Miscellaneous ROMs
+;7654 3210
+;---------
+;.... ..RR
+;       ++- Number of miscellaneous ROMs present
+;
+;Byte 14.
+.byte $00                       ; No extra ROM chips
+
+;----------------------------------------------------------------------------------------------------
+
+;Default Expansion Device
+;7654 3210
+;---------
+;..DD DDDD
+;  ++-++++- Default Expansion Device;
+;
+;Byte 15
+.byte $01                       ; Use normal NES/Famicom controllers by default

--- a/tools/checksum.py
+++ b/tools/checksum.py
@@ -1,8 +1,8 @@
 from hashlib import md5
 
 rebuilt_rom = "mother_rebuilt.nes"
-hash_us = ["5bacf7ba94c539a1caf623dbe12059a3", "54387b6e68142d69083a38b437196450"]
-hash_jp = ["218503a880999363ac83945096040492"]
+hash_us = "54387b6e68142d69083a38b437196450"
+hash_jp = "bf1e0bc9c390fdbb2b3ca22d784db7d2"
 
 if __name__ == "__main__":
     import argparse
@@ -28,9 +28,10 @@ if __name__ == "__main__":
     if args.japanese:
         hash1 = hash_jp #jp hash
 
-    for hash in hash1:
-        if hash == md5(open(rebuilt_rom, "rb").read()).hexdigest():
-            print("OK")
-            exit()
+    with open(rebuilt_rom, "rb") as f:
+        rebuilt_hash = md5(f.read()).hexdigest()
+    if rebuilt_hash == hash1:
+        print("OK")
+        exit()
     #if no match
     raise Exception("Hashes do not match")


### PR DESCRIPTION
No-Intro has switched over to NES 2.0 for everything, meaning it doesn't list hashes for the older header format. Use a NES 2.0 header when assembling ROMs so that we match these new hashes and it's easier to verify that this repo is building what it says it is.

Also add NES 2.0 ROM input hash for Mother 1, and try to remove a hardcoded reference to /bin/bash that doesn't work on Windows.