### PR TITLE
more labeling of constant.asm

### DIFF
--- a/src/global/prg/naming_screen.asm
+++ b/src/global/prg/naming_screen.asm
@@ -43,9 +43,9 @@ rts_1:
 ;x == index * 2
 ns_load_ui_element:
     lda B25_1873, x
-    sta UNK_74
+    sta tilepack_ptr
     lda B25_1873+1, x
-    sta UNK_74+1
+    sta tilepack_ptr+1
     rts
 
 rts_3:
@@ -617,7 +617,7 @@ NS_AddCharacterToOam:
     sta shadow_something+7, y
 
     lda #1
-    sta UNK_E5
+    sta nmi_flags
 
     rts
 

--- a/src/global/ram.asm
+++ b/src/global/ram.asm
@@ -77,7 +77,7 @@ UNK_70: .res 1
 UNK_71: .res 1
 UNK_72: .res 1
 UNK_73: .res 1
-UNK_74: .res 2 ;tile data pointer
+tilepack_ptr: .res 2        ; $74
 UNK_76: .res 1
 UNK_77: .res 1
 UNK_78: .res 1
@@ -86,8 +86,8 @@ UNK_7A: .res 1
 UNK_7B: .res 1
 UNK_7C: .res 1
 UNK_7D: .res 1
-UNK_7E: .res 1
-UNK_7F: .res 1
+char_count: .res 1          ; counts chars (not charas...)
+byte_count: .res 1          ; counts bytes (todo: find purpose)
 UNK_80: .res 2
 
 ; Position of menu cursor in whole numbers, incrementing by 1 per step
@@ -154,15 +154,16 @@ pad1_hold: .res 1 ; $de
 pad2_hold: .res 1 ; $df
 UNK_E0: .res 1
 UNK_E1: .res 1
-UNK_E2: .res 1
+oam_and_300_clear_flag: .res 1      ; Set Bit 7 before Clear OAM & $300 are, Free bit after
 UNK_E3: .res 1
 UNK_E4: .res 1
-UNK_E5: .res 2 ;some kind of pointer
+nmi_flags: .res 1 ;some kind of pointer (TODO: change name to something less similar to nmi flag)
+nmi_data_offset: .res 1
 UNK_E7: .res 1
-UNK_E8: .res 1
-UNK_E9: .res 1
+shift_x: .res 1
+shift_y: .res 1
 nmi_flag: .res 1 ; $ea ; 01 = waiting for NMI, 80 = is running NMI handler ;ignores controller input while set
-UNK_EB: .res 1
+irq_latch: .res 1
 irq_count: .res 1      ; IRQ Count
 irq_index: .res 1 ; $ed ; IRQ routine index (multiple of 2)
 bankswitch_mode: .res 1 ; $ee ; Bankswitch "mode"  (-----mmm), $8000 MMC3 register
@@ -454,7 +455,7 @@ unk_7e6 = $07e6
 unk_7e7 = $07e7
 unk_7e8 = $07e8
 
-unk_7ef = $07ef ; $07EF = Unknown (initialized to $C0)
+sram_mode = $07ef
 
 ; Sounds
 ; direct sfx (put into soundqueues)

--- a/src/jp/prg/bank13.asm
+++ b/src/jp/prg/bank13.asm
@@ -43,7 +43,7 @@ SelectOpenFullStats:
     ;if failed, jump
     bcs B19_0084
     ;else,
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     ;stash x
     txa
     pha
@@ -188,7 +188,7 @@ B19_00e5:
     sta $74
     stx $75
 B19_00ed:
-    jsr B30_06db
+    jsr DrawTilepackClear
     cmp #$00
     bne B19_00ed
     rts
@@ -1541,7 +1541,7 @@ OA_End:
 
 MOV_word60_word40:
     lda $28
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     lda temp_word
     sta tableentry_var
     lda temp_word+1
@@ -1716,7 +1716,7 @@ PlayerUsableBitfieldLUT:
 
 ReadOverworldMessageLUT:
     lda OverworldMessageLUT, x
-    sta UNK_74
+    sta tilepack_ptr
     lda OverworldMessageLUT+1, x
     sta UNK_73
     rts
@@ -1973,14 +1973,14 @@ OverworldScriptLUT:
 OINST_InfiniteLoop:
     jmp OINST_InfiniteLoop
 
-;render UNK_74
+;render tilepack_ptr
 B19_0c44:
-    sta UNK_74
-    stx UNK_74+1
+    sta tilepack_ptr
+    stx tilepack_ptr+1
     .ifdef VER_JP
-    jmp B30_06db
+    jmp DrawTilepackClear
     .else
-    jmp B30_06d2
+    jmp DrawTilepack
     .endif
 
 ; Instruction 0F - Reset game
@@ -2175,7 +2175,7 @@ B19_0d40:
     lda #$12
     sta $70
     ldy #0
-    lda (UNK_74),y
+    lda (tilepack_ptr),y
     eor #$90
     beq @yeah
     lda #1
@@ -2187,12 +2187,12 @@ B19_0d40:
     lda #0
     sta $71
     .endif
-    jsr B30_0707
+    jsr PRINT_STRING
     jsr B30_07af
     cmp #0
     beq B19_0d61
     ldy #0
-    lda (UNK_74), y
+    lda (tilepack_ptr), y
     cmp #3
     beq B19_0d75
     cmp #0
@@ -2244,7 +2244,7 @@ B19_0d98:
     ldy #$ca
     @four:
     jsr PpuSync
-    sty UNK_E5+1
+    sty nmi_flags+1
     @three:
     lda nmi_queue+0,y
     beq @one
@@ -2278,16 +2278,16 @@ B19_0d98:
     bcc @three
     @one:
     sec
-    lda UNK_E5+1
+    lda nmi_flags+1
     sbc #$36
     tay
     lda #$80
-    sta UNK_E5+0
+    sta nmi_flags+0
     cpy #$5e
     bcs @four
     dec UNK_77
     dec UNK_77
-    lda UNK_74+0
+    lda tilepack_ptr+0
     pha
     lda UNK_73
     pha
@@ -2299,11 +2299,11 @@ B19_0d98:
     pla
     sta UNK_73
     pla
-    sta UNK_74+0
+    sta tilepack_ptr+0
     rts
 .else
     ldx #4
-    jsr B30_07c1
+    jsr DELAY_PRINT_SCROLL
     dec $77
     dec $77
     rts
@@ -2829,7 +2829,7 @@ B19_107e:
     rts
 
 GetInventoryPointer:
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     clc
     lda temp_word
     adc #$20
@@ -3593,7 +3593,7 @@ OINST_MultiplyByPartySize:
 B19_151d:
     jsr GetXCharacter
     bcs B19_153d
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     ldy #1
     lda (temp_vars), y
     bmi B19_153d
@@ -3635,7 +3635,7 @@ B19_1561:
 B19_1566:
     lda party_members, x
     beq B19_157a
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     ldy #1
     lda (temp_vars), y
     bmi B19_157a
@@ -3692,7 +3692,7 @@ B19_15c2:
     sty $35
 B19_15c4:
     lda $28
-    jmp GetPartyMemberData
+    jmp GetPartyMemberPtr
 
 ; Instruction 60 - Jump to J if < max pp
 OINST_JMP_CharaPPNotFull:
@@ -4570,7 +4570,7 @@ B19_19e4:
     lda #.LOBYTE(B19_1ab6)
     ldx #.HIBYTE(B19_1ab6)
     jsr B19_0c44
-    jsr B30_06db
+    jsr DrawTilepackClear
     ldx #$29
     @loop:
     lda $bba2,x
@@ -4658,7 +4658,7 @@ B19_19e4:
     lda #.LOBYTE(B19_1ab6)
     ldx #.HIBYTE(B19_1ab6)
     jsr B19_0c44
-    jsr B30_06d2
+    jsr DrawTilepack
     ldx #$00
     jsr B19_1a72
     jsr B19_1a72
@@ -4835,7 +4835,7 @@ PartyContentTrue_Choicer:
     .byte 6, 5 ; X/Y start
 
 B19_1b21:
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     clc
     lda temp_word
     adc #$38
@@ -4850,7 +4850,7 @@ B19_1b21:
     sta $70
     stx $76
     sty $77
-    jmp B30_06db
+    jmp DrawTilepackClear
     .else
     lda #7
     ldx #9
@@ -4858,7 +4858,7 @@ B19_1b21:
     sta $70
     stx $76
     sty $77
-    jmp B30_06d2
+    jmp DrawTilepack
     .endif
 
 B19_1b40:
@@ -4942,9 +4942,9 @@ B19_1baf:
     lda (temp_vars), y
     sta $75
     .ifdef VER_JP
-    jsr B30_06db
+    jsr DrawTilepackClear
     .else
-    jsr B30_06d2
+    jsr DrawTilepack
     .endif
     jmp B19_0b41
 
@@ -5310,7 +5310,7 @@ OT5_Flood:
     tax
     dey
     bpl B19_1dea
-    jsr BankswitchLower_Bank20
+    jsr BANKSET_H14
     jsr B20_1641
     lda #$11
     jsr BackupAndFillPalette

--- a/src/jp/prg/bank14.asm
+++ b/src/jp/prg/bank14.asm
@@ -445,7 +445,7 @@ Title_Screen := $9e23
 
 intro:
     ;use bank $13 as lower half
-    jsr BankswitchUpper_Bank19
+    jsr BANKSET_H13
 
     ;title routine
     jsr Title_Screen
@@ -541,7 +541,7 @@ something_init:
     pla
     jsr SetupFreshSaveData
     jsr WriteProtectPRGRam
-    jsr BankswitchUpper_Bank19
+    jsr BANKSET_H13
 
     ;do naming sequence
     jsr NS_NamingSequence

--- a/src/us/prg/antipiracy.asm
+++ b/src/us/prg/antipiracy.asm
@@ -31,9 +31,9 @@ ANTI_PIRACY:
     lda #0
     sta nmi_queue+$16
 
-    sta UNK_E5+1
+    sta nmi_flags+1
     lda #.HIBYTE($8000)
-    sta UNK_E5
+    sta nmi_flags
 
     jsr PpuSync
 
@@ -111,9 +111,9 @@ B25_0079:
     @loop:
 
     lda #.LOBYTE($8000)
-    sta UNK_E5+1
+    sta nmi_flags+1
     lda #.HIBYTE($8000)
-    sta UNK_E5
+    sta nmi_flags
 
     jsr PpuSync
 
@@ -208,11 +208,11 @@ B25_01f8:
     sta $71
     B25_0238:
     jsr GetTextData
-    jsr B30_06db
+    jsr DrawTilepackClear
     cmp #$00
     beq B25_024a
     ldy #$00
-    lda ($74), y
+    lda (tilepack_ptr), y
     cmp #$00
     bne B25_0238
     B25_024a:
@@ -693,7 +693,7 @@ RepelRing_Effect:
     jsr TempUpperBankswitch
 
     ;rts
-    jmp BankswitchLower_Bank20
+    jmp BANKSET_H14
 
 Repel_LevelTable:
 .byte 0,3,5,7,10,12,16,18,19,21,23,26,28,30,35,36,37,-1

--- a/src/us/prg/bank13.asm
+++ b/src/us/prg/bank13.asm
@@ -43,7 +43,7 @@ SelectOpenFullStats:
     ;if failed, jump
     bcs B19_0084
     ;else,
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     ;stash x
     txa
     pha
@@ -188,7 +188,7 @@ B19_00e5:
     sta $74
     stx $75
 B19_00ed:
-    jsr B30_06db
+    jsr DrawTilepackClear
     cmp #$00
     bne B19_00ed
     rts
@@ -1455,7 +1455,7 @@ OA_End:
 
 MOV_word60_word40:
     lda $28
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     lda temp_word
     sta tableentry_var
     lda temp_word+1
@@ -1630,7 +1630,7 @@ PlayerUsableBitfieldLUT:
 
 ReadOverworldMessageLUT:
     lda OverworldMessageLUT, x
-    sta UNK_74
+    sta tilepack_ptr
     lda OverworldMessageLUT+1, x
     sta UNK_73
     rts
@@ -1881,11 +1881,11 @@ OverworldScriptLUT:
 OINST_InfiniteLoop:
     jmp OINST_InfiniteLoop
 
-;render UNK_74
+;render tilepack_ptr
 B19_0c44:
-    sta UNK_74
-    stx UNK_74+1
-    jmp B30_06d2
+    sta tilepack_ptr
+    stx tilepack_ptr+1
+    jmp DrawTilepack
 
 ; Instruction 0F - Reset game
 OINST_Reset:
@@ -2077,12 +2077,12 @@ B19_0d40:
     sta $70
     lda #0
     sta $71
-    jsr B30_0707
+    jsr PRINT_STRING
     jsr B30_07af
     cmp #0
     beq B19_0d61
     ldy #0
-    lda ($74), y
+    lda (tilepack_ptr), y
     cmp #3
     beq B19_0d75
     cmp #0
@@ -2122,7 +2122,7 @@ B19_0d91:
 
 B19_0d98:
     ldx #4
-    jsr B30_07c1
+    jsr DELAY_PRINT_SCROLL
     dec $77
     dec $77
     rts
@@ -2623,7 +2623,7 @@ B19_107e:
     rts
 
 GetInventoryPointer:
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     clc
     lda temp_word
     adc #$20
@@ -3354,7 +3354,7 @@ OINST_MultiplyByPartySize:
 B19_151d:
     jsr GetXCharacter
     bcs B19_153d
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     ldy #1
     lda (temp_vars), y
     bmi B19_153d
@@ -3396,7 +3396,7 @@ B19_1561:
 B19_1566:
     lda party_members, x
     beq B19_157a
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     ldy #1
     lda (temp_vars), y
     bmi B19_157a
@@ -3453,7 +3453,7 @@ B19_15c2:
     sty $35
 B19_15c4:
     lda $28
-    jmp GetPartyMemberData
+    jmp GetPartyMemberPtr
 
 ; Instruction 60 - Jump to J if < max pp
 OINST_JMP_CharaPPNotFull:
@@ -4096,7 +4096,7 @@ B19_19e4:
     lda #.LOBYTE(B19_1ab6)
     ldx #.HIBYTE(B19_1ab6)
     jsr B19_0c44
-    jsr B30_06d2
+    jsr DrawTilepack
     ldx #$00
     jsr B19_1a72
     jsr B19_1a72
@@ -4257,7 +4257,7 @@ PartyContentTrue_Choicer:
     .byte 6, 5 ; X/Y start
 
 B19_1b21:
-    jsr GetPartyMemberData
+    jsr GetPartyMemberPtr
     clc
     lda temp_word
     adc #$38
@@ -4271,7 +4271,7 @@ B19_1b21:
     sta $70
     stx $76
     sty $77
-    jmp B30_06d2
+    jmp DrawTilepack
 
 B19_1b40:
     lda #$0b
@@ -4342,7 +4342,7 @@ B19_1baf:
     iny
     lda (temp_vars), y
     sta $75
-    jsr B30_06d2
+    jsr DrawTilepack
     jmp B19_0b41
 
 B19_1bc3:
@@ -4700,7 +4700,7 @@ OT5_Flood:
     tax
     dey
     bpl B19_1dea
-    jsr BankswitchLower_Bank20
+    jsr BANKSET_H14
     jsr B20_1641
     lda #$11
     jsr BackupAndFillPalette

--- a/src/us/prg/credits.asm
+++ b/src/us/prg/credits.asm
@@ -19,8 +19,8 @@ Credits_Entry:
     sta UNK_E7
 
     lda #0
-    sta UNK_E8
-    sta UNK_E9
+    sta shift_x
+    sta shift_y
 
     ;reset Base nametable address
     lda ram_PPUCTRL
@@ -112,7 +112,7 @@ credits_cmd_delay:
     @loop:
     jsr PpuSync
     lda #1
-    sta UNK_E5
+    sta nmi_flags
     dex
     bne @loop
 
@@ -254,9 +254,9 @@ credits_cmd_set_metatileprops:
     bne B26_011b
     lda #.LOBYTE($8000)
     sta nmi_queue+4, x
-    sta UNK_E5+1
+    sta nmi_flags+1
     lda #.HIBYTE($8000)
-    sta UNK_E5
+    sta nmi_flags
     dec UNK_42
     beq B26_0151
     jsr PpuSync
@@ -304,9 +304,9 @@ credits_cmd_set_palette:
 
     lda #0
     sta nmi_queue+1 ; END
-    sta UNK_E5+1 ;.LOBYTE($8000)
+    sta nmi_flags+1 ;.LOBYTE($8000)
     lda #.HIBYTE($8000)
-    sta UNK_E5
+    sta nmi_flags
 
     ;set to after command
     ldy #$11
@@ -474,7 +474,7 @@ credits_cmd_draw_text:
     ;get next word
     iny
     lda (UNK_40), y
-    sta UNK_74
+    sta tilepack_ptr
     iny
     lda (UNK_40), y
     sta UNK_73
@@ -492,11 +492,11 @@ credits_cmd_draw_text:
     @loop:
     jsr GetTextData
 
-    jsr B30_06db
+    jsr DrawTilepackClear
     cmp #0
     beq @break
     ldy #0
-    lda (UNK_74), y
+    lda (tilepack_ptr), y
     cmp #0
     bne @loop
 
@@ -523,9 +523,9 @@ credits_cmd_draw_text:
     ldx #2
     @loop2:
     lda #.LOBYTE($8000)
-    sta UNK_E5+1
+    sta nmi_flags+1
     lda #.HIBYTE($8000)
-    sta UNK_E5
+    sta nmi_flags
 
     dex
     beq @break2
@@ -549,7 +549,7 @@ credits_cmd_draw_text_xy:
     ;get next umsg
     iny
     lda (UNK_40), y
-    sta UNK_74
+    sta tilepack_ptr
     iny
     lda (UNK_40), y
     sta UNK_73
@@ -569,7 +569,7 @@ credits_cmd_draw_text_xy:
     sta UNK_71
 
     jsr GetTextData
-    jsr B30_06db
+    jsr DrawTilepackClear
 
     ;bye
     ldy #$05


### PR DESCRIPTION
- changed Bankswitch to BANKSWAP, BANKSET (preserve current bank vs no preserve current bank)
- label large parts of core engine code (PRINT_STRING)
- change some ram variable names, namely in $E? range which is always reserved for engine work (in constant.asm & other banks that work with strings/printing strings to screen)